### PR TITLE
fix: remove await when putting value into promiseCache

### DIFF
--- a/src/promiseCache.ts
+++ b/src/promiseCache.ts
@@ -34,9 +34,9 @@ export class PromiseCache<K, V> {
     return typeof key === 'string' ? key : JSON.stringify(key);
   }
 
-  async put(key: K, value: Promise<V>): Promise<V> {
+  put(key: K, value: Promise<V>): Promise<V> {
     this.cache.write(this.cacheKeyString(key), value);
-    return await value;
+    return value;
   }
 
   get(key: K): Promise<V> | undefined {


### PR DESCRIPTION
Validating if awaiting this `put` is the cause for `uncaught exceptions` when using the `ReadThroughPromiseCache`.

Merging this will create an `alpha` release we can use to test.